### PR TITLE
Add ArrayToCSV function

### DIFF
--- a/snippets/arrayToCSV.md
+++ b/snippets/arrayToCSV.md
@@ -1,0 +1,30 @@
+### arrayToCSV
+
+Return a CSV-formatted string representation for given array-of-arrays, optionally specifying the column delimiter. 
+
+Numeric values are rendered as-is, strings are enclosed double quotes (") and double quotes within strings are escaped with a double quote ("").
+
+```php
+function arrayToCSV($rows, $del = ',')
+{
+    $escape = function ($x) {
+        return is_numeric($x) ? $x : '"'.str_replace('"', '""', $x).'"';
+    };
+    $rowToCsv = function ($row) use ($del, $escape) {
+        return implode($del, array_map($escape, $row));
+    };
+    return implode("\n", array_map($rowToCsv, $rows));
+}
+```
+
+<details>
+<summary>Examples</summary>
+
+```php
+arrayToCSV([['a', '"b" good'], ['delta', 3.14159], ['c', 42]])
+// "a","""b"" good"
+// "delta",3.14159
+// "c",42
+```
+
+</details>

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -324,6 +324,17 @@ function orderBy($items, $attr, $order)
     return array_values($sortedItems);
 }
 
+function arrayToCSV($rows, $del = ',')
+{
+    $escape = function ($x) {
+        return is_numeric($x) ? $x : '"'.str_replace('"', '""', $x).'"';
+    };
+    $rowToCSV = function ($row) use ($del, $escape) {
+        return implode($del, array_map($escape, $row));
+    };
+    return implode("\n", array_map($rowToCSV, $rows));
+}
+
 function memoize($func)
 {
     return function () use ($func) {

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -243,4 +243,13 @@ class ArrayTest extends TestCase
             )
         );
     }
+
+    public function testArrayToCSV()
+    {
+        // Intentionally testing using a delimiter other than the default.
+        $this->assertEquals(
+            '"a"'."\t".'"""b"" good"'."\n".'"c"'."\t3.14",
+            arrayToCSV([['a', '"b" good'], ['c', 3.14]], "\t")
+        );
+    }
 }


### PR DESCRIPTION
New function that takes an array of arrays (ie, a list of rows), and formats as CSV.

Please note this isn't a straight port of the equivalent function in the 30-seconds JS repo, since that one doesn't seem to correctly quote/escape strings values.

This I think is the smallest possible function that will always create a valid CSV for any standard parser (assuming non-multibyte strings).