### PR TITLE
Improve flatten and deepFlatten performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ any([1, 2, 3, 4], function ($item) {
 Deep flattens an array.
 
 Use recursion.
-Use `array_merge` with an empty array to flatten the array.
+Use `array_push`, splat operator and an empty array to flatten the array.
 Recursively flatten each element that is an array.
 
 ```php
@@ -171,7 +171,7 @@ function deepFlatten($items)
     if (!is_array($item)) {
       $result[] = $item;
     } else {
-      $result = array_merge($result, deepFlatten($item));
+      array_push($result, ...deepFlatten($item));
     }
   }
 
@@ -274,7 +274,7 @@ findLastIndex([1, 2, 3, 4], function ($n) {
 
 Flattens an array up to the one level depth.
 
-Use `array_merge()` and `array_values()` to flatten the array.
+Use `array_push()`, splat operator and `array_values()` to flatten the array.
 
 ```php
 function flatten($items)
@@ -284,7 +284,7 @@ function flatten($items)
     if (!is_array($item)) {
       $result[] = $item;
     } else {
-      $result = array_merge($result, array_values($item));
+      array_push($result, ...array_values($item));
     }
   }
 

--- a/snippet_data/snippetList.json
+++ b/snippet_data/snippetList.json
@@ -141,7 +141,7 @@
       "type": "snippetListing",
       "title": "deepFlatten",
       "attributes": {
-        "text": "Deep flattens an array.\n\nUse recursion.\nUse `array_merge` with an empty array to flatten the array.\nRecursively flatten each element that is an array.\n\n",
+        "text": "Deep flattens an array.\n\nUse recursion.\nUse `array_push`, splat operator and an empty array to flatten the array.\nRecursively flatten each element that is an array.\n\n",
         "tags": [
           "array",
           "recursion",
@@ -263,7 +263,7 @@
       "type": "snippetListing",
       "title": "flatten",
       "attributes": {
-        "text": "Flattens an array up to the one level depth.\n\nUse `array_merge()` and `array_values()` to flatten the array.\n\n",
+        "text": "Flattens an array up to the one level depth.\n\nUse `array_push()`, splat operator and `array_values()` to flatten the array.\n\n",
         "tags": [
           "array",
           "intermediate"

--- a/snippet_data/snippets.json
+++ b/snippet_data/snippets.json
@@ -187,9 +187,9 @@
       "type": "snippet",
       "attributes": {
         "fileName": "deepFlatten.md",
-        "text": "Deep flattens an array.\n\nUse recursion.\nUse `array_merge` with an empty array to flatten the array.\nRecursively flatten each element that is an array.\n\n",
+        "text": "Deep flattens an array.\n\nUse recursion.\nUse `array_push`, splat operator and an empty array to flatten the array.\nRecursively flatten each element that is an array.\n\n",
         "codeBlocks": {
-          "code": "function deepFlatten($items)\n{\n  $result = [];\n  foreach ($items as $item) {\n    if (!is_array($item)) {\n      $result[] = $item;\n    } else {\n      $result = array_merge($result, deepFlatten($item));\n    }\n  }\n\n  return $result;\n}",
+          "code": "function deepFlatten($items)\n{\n  $result = [];\n  foreach ($items as $item) {\n    if (!is_array($item)) {\n      $result[] = $item;\n    } else {\n      array_push($result, ...deepFlatten($item));\n    }\n  }\n\n  return $result;\n}",
           "example": "deepFlatten([1, [2], [[3], 4], 5]); // [1, 2, 3, 4, 5]"
         },
         "tags": [
@@ -349,9 +349,9 @@
       "type": "snippet",
       "attributes": {
         "fileName": "flatten.md",
-        "text": "Flattens an array up to the one level depth.\n\nUse `array_merge()` and `array_values()` to flatten the array.\n\n",
+        "text": "Flattens an array up to the one level depth.\n\nUse `array_push()`, splat operator and `array_values()` to flatten the array.\n\n",
         "codeBlocks": {
-          "code": "function flatten($items)\n{\n  $result = [];\n  foreach ($items as $item) {\n    if (!is_array($item)) {\n      $result[] = $item;\n    } else {\n      $result = array_merge($result, array_values($item));\n    }\n  }\n\n  return $result;\n}",
+          "code": "function flatten($items)\n{\n  $result = [];\n  foreach ($items as $item) {\n    if (!is_array($item)) {\n      $result[] = $item;\n    } else {\n      array_push($result, ...array_values($item));\n    }\n  }\n\n  return $result;\n}",
           "example": "flatten([1, [2], 3, 4]); // [1, 2, 3, 4]"
         },
         "tags": [

--- a/snippets/deepFlatten.md
+++ b/snippets/deepFlatten.md
@@ -6,7 +6,7 @@ tags: array,recursion,intermediate
 Deep flattens an array.
 
 Use recursion.
-Use `array_merge` with an empty array to flatten the array.
+Use `array_push`, splat operator and an empty array to flatten the array.
 Recursively flatten each element that is an array.
 
 ```php
@@ -17,7 +17,7 @@ function deepFlatten($items)
     if (!is_array($item)) {
       $result[] = $item;
     } else {
-      $result = array_merge($result, deepFlatten($item));
+      array_push($result, ...deepFlatten($item));
     }
   }
 

--- a/snippets/flatten.md
+++ b/snippets/flatten.md
@@ -5,7 +5,7 @@ tags: array,intermediate
 
 Flattens an array up to the one level depth.
 
-Use `array_merge()` and `array_values()` to flatten the array.
+Use `array_push()`, splat operator and `array_values()` to flatten the array.
 
 ```php
 function flatten($items)
@@ -15,7 +15,7 @@ function flatten($items)
     if (!is_array($item)) {
       $result[] = $item;
     } else {
-      $result = array_merge($result, array_values($item));
+      array_push($result, ...array_values($item));
     }
   }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,7 +17,7 @@ function flatten($items)
         if (!is_array($item)) {
             $result[] = $item;
         } else {
-            $result = array_merge($result, array_values($item));
+            array_push($result, ...array_values($item));
         }
     }
 
@@ -31,7 +31,7 @@ function deepFlatten($items)
         if (!is_array($item)) {
             $result[] = $item;
         } else {
-            $result = array_merge($result, deepFlatten($item));
+            array_push($result, ...deepFlatten($item));
         }
     }
 


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

When merging big arrays, `array_merge` is too slow. `array_merge` performs many operations with the keys that actually we don't need. We use `array_values` so those operations are pointless.

Comparison:
```php
$arr = range(1, 50000);

foreach ($arr as $key => $value) {
    $arr[$key] = array_fill(0, 10, 'test');
}
```

Using `array_merge()`:
[Source](https://3v4l.org/sT5hm)
![Screen Shot 2019-10-09 at 8 35 46 PM](https://user-images.githubusercontent.com/11374198/66590757-793d6d00-eb5f-11e9-9c83-0f7284d62544.png)

Using `array_push()`:
[Source](https://3v4l.org/bkKaU)
![Screen Shot 2019-10-09 at 8 33 35 PM](https://user-images.githubusercontent.com/11374198/66590772-82c6d500-eb5f-11e9-9fea-a13536b47d17.png)


## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specifiy in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-starter/blob/master/CONTRIBUTING.md) document.
