### PR TITLE
[FEATURE] Convert a string to a slug which is URL friendly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php" : ">=5.6.0"
+        "php": ">=5.6.0",
+        "ext-iconv": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "5.5|^6.5",

--- a/snippets/slugify.md
+++ b/snippets/slugify.md
@@ -3,36 +3,22 @@ title:  slugify
 tags: string,intermediate
 ---
 
-Converts a string to a slug which is URL friendly.
+Converts a string to a URL-friendly slug.
 
-Uses `preg_replace()` to replace invalid chars with dashes, `iconv()` to convert the text to ASCII which is URL friendly, `strtolower()` as slugs should be lower case and `trim()` to do the cleanup.
+Uses `preg_replace()` to replace invalid chars with dashes, `iconv()` to convert the text to ASCII, `strtolower()` and `trim()` to convert to lowercase and remove extra whitespace.
 
 ```php
-function slugify($text)
-{
-    // replace non alpha-numeric chars by dash
-    $text = preg_replace('~[^\pL\d]+~u', '-', $text);
-
-    // transliterate, requires ext-iconv
-    $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
-
-    // remove unwanted characters
-    $text = preg_replace('~[^-\w]+~', '', $text);
-
-    // remove duplicate dash
-    $text = preg_replace('~-+~', '-', $text);
-
-    // lowercase
-    $text = strtolower($text);
-    
-    // cleanup
-    $text = trim($text, " \t\n\r\0\x0B-");
-
-    if (empty($text)) {
-        return 'n-a';
-    }
-
-    return $text;
+function slugify($text) {
+  $text = preg_replace('~[^\pL\d]+~u', '-', $text);
+  $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+  $text = preg_replace('~[^-\w]+~', '', $text);
+  $text = preg_replace('~-+~', '-', $text);
+  $text = strtolower($text);
+  $text = trim($text, " \t\n\r\0\x0B-");
+  if (empty($text)) {
+    return 'n-a';
+  }
+  return $text;
 }
 ```
 

--- a/snippets/slugify.md
+++ b/snippets/slugify.md
@@ -1,0 +1,41 @@
+---
+title:  slugify
+tags: string,intermediate
+---
+
+Converts a string to a slug which is URL friendly.
+
+Uses `preg_replace()` to replace invalid chars with dashes, `iconv()` to convert the text to ASCII which is URL friendly, `strtolower()` as slugs should be lower case and `trim()` to do the cleanup.
+
+```php
+function slugify($text)
+{
+    // replace non alpha-numeric chars by dash
+    $text = preg_replace('~[^\pL\d]+~u', '-', $text);
+
+    // transliterate, requires ext-iconv
+    $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+
+    // remove unwanted characters
+    $text = preg_replace('~[^-\w]+~', '', $text);
+
+    // remove duplicate dash
+    $text = preg_replace('~-+~', '-', $text);
+
+    // lowercase
+    $text = strtolower($text);
+    
+    // cleanup
+    $text = trim($text, " \t\n\r\0\x0B-");
+
+    if (empty($text)) {
+        return 'n-a';
+    }
+
+    return $text;
+}
+```
+
+```php
+slugify('Hello World'); // 'hello-world'
+```

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -411,3 +411,30 @@ function shorten($input, $length = 100, $end = '...')
 
     return rtrim(mb_substr($input, 0, $length, 'UTF-8')) . $end;
 }
+
+function slugify($text)
+{
+    // replace non alpha-numeric chars by dash
+    $text = preg_replace('~[^\pL\d]+~u', '-', $text);
+
+    // transliterate
+    $text = iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+
+    // remove unwanted characters
+    $text = preg_replace('~[^-\w]+~', '', $text);
+
+    // remove duplicate dash
+    $text = preg_replace('~-+~', '-', $text);
+
+    // lowercase
+    $text = strtolower($text);
+
+    // cleanup
+    $text = trim($text, " \t\n\r\0\x0B-");
+
+    if (empty($text)) {
+        return 'n-a';
+    }
+
+    return $text;
+}

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -89,4 +89,13 @@ class StringTest extends TestCase
     {
         $this->assertSame('The quick brown...', shorten('The quick brown fox jumped over the lazy dog', 15));
     }
+
+    public function testSlugify()
+    {
+        $this->assertSame('hello-world', slugify('Hello World'));
+        $this->assertSame('hello-world', slugify('"Hello World"'));
+        $this->assertSame('hello-world-92', slugify('Hello World 92'));
+        $this->assertSame('hello-world-92', slugify('Hello_World/~92'));
+        $this->assertSame('das-madchen-dunn-schon', slugify('das Mädchen dünn schön')); // non-ascii
+    }
 }


### PR DESCRIPTION
## Description
Added a new snippet, converting text to slugs which can be used in the URLs.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to the content, typos, general stuff and metafiles in the repository - e.g. the issue template)
- [ ] Other (please specify in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-starter/blob/master/CONTRIBUTING.md) document.
